### PR TITLE
Copy contents, not the folder

### DIFF
--- a/lib/wraith/folder.rb
+++ b/lib/wraith/folder.rb
@@ -34,7 +34,7 @@ class Wraith::FolderManager
   end
 
   def copy_old_shots
-    FileUtils.cp_r(dir, history_dir)
+    FileUtils.cp_r("#{dir}/.", "#{history_dir}/")
   end
 
   def restore_shots


### PR DESCRIPTION
The `FolderManager#copy_old_shots` method, as it currently stands, copies the old folder **inside** the history folder, if the old folder and the history folder exist. This, in turn, causes all kinds of problems (like not being able to generate gallery files, etc).

The correct way is to copy folder contents is [apparently](http://stackoverflow.com/a/4645159/98634) via an extra `.`