### PR TITLE
Add highlight color option

### DIFF
--- a/lib/wraith/compare_images.rb
+++ b/lib/wraith/compare_images.rb
@@ -27,7 +27,7 @@ class Wraith::CompareImages
   end
 
   def compare_task(base, compare, output, info)
-    cmdline = "compare -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color blue #{base} #{compare} #{output}"
+    cmdline = "compare -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare} #{output}"
     px_value = Open3.popen3(cmdline) { |_stdin, _stdout, stderr, _wait_thr| stderr.read }.to_f
     begin
       img_size = ImageSize.path(output).size.inject(:*)

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -80,7 +80,7 @@ class Wraith::Wraith
   end
 
   def highlight_color
-    @config['highlight_color']
+    @config['highlight_color'] ? @config['highlight_color'] : 'blue'
   end
 
   def mode

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -79,6 +79,10 @@ class Wraith::Wraith
     @config['fuzz']
   end
 
+  def highlight_color
+    @config['highlight_color']
+  end
+
   def mode
     if %w(diffs_only diffs_first alphanumeric).include?(@config['mode'])
       @config['mode']


### PR DESCRIPTION
I was missing the option for defining the highlight color when diffing the captured screenshots.

Instead of doing this:
```ruby
@config['highlight_color'] ? @config['highlight_color'] : 'blue'
```

should I instead have done it like:
```ruby
@config['highlight_color'] || 'blue'
```

Or how is that normally done in Ruby?

----

Please let me know if you want me to squash the commits or anything else.