### PR TITLE
Standardizing on using double quotes

### DIFF
--- a/component.html
+++ b/component.html
@@ -69,7 +69,7 @@ browser:
 snap_file: "javascript/casper.js"
 
 # Type the name of the directory that shots will be stored in
-directory: 'shots'
+directory: "shots"
 
 # Add only 2 domains, key will act as a label
 domains:
@@ -88,10 +88,10 @@ screen_widths:
 paths:
   brand:
     path: /
-    selector: '.site-brand'
+    selector: ".site-brand"
 
 #Amount of fuzz ImageMagick will use
-fuzz: '20%'
+fuzz: "20%"
 
 #Choose how results are displayed, by default alphanumeric. Different screen widths are always grouped.
 #alphanumeric - all paths (with, and without, a difference) are shown, sorted by path

--- a/history.html
+++ b/history.html
@@ -69,8 +69,8 @@ browser:
 snap_file: "javascript/snap.js"
 
 # Type the name of the directory that shots will be stored in
-directory: 'shots'
-history_dir: 'shots_history'
+directory: "shots"
+history_dir: "shots_history"
 
 # Add only 2 domains, key will act as a label
 domains:
@@ -90,7 +90,7 @@ paths:
   uk_index: /uk
 
 #Amount of fuzz ImageMagick will use
-fuzz: '20%'
+fuzz: "20%"
 
 #Choose how results are displayed, by default alphanumeric. Different screen widths are always grouped.
 #alphanumeric - all paths (with, and without, a difference) are shown, sorted by path

--- a/spider.html
+++ b/spider.html
@@ -69,7 +69,7 @@ browser:
 snap_file: "javascript/snap.js"
 
 # Type the name of the directory that shots will be stored in
-directory: 'shots'
+directory: "shots"
 
 # Add only 2 domains, key will act as a label
 domains:
@@ -85,7 +85,7 @@ screen_widths:
   - 1280
 
 #Amount of fuzz ImageMagick will use
-fuzz: '20%'
+fuzz: "20%"
 
 #Set the filename of the spider file to use, if not specified it will fallback to spider.txt
  spider_file: bbc_co_uk_spider.txt

--- a/standard.html
+++ b/standard.html
@@ -69,7 +69,7 @@ browser:
 snap_file: "javascript/snap.js"
 
 # Type the name of the directory that shots will be stored in
-directory: 'shots'
+directory: "shots"
 
 # Add only 2 domains, key will act as a label
 domains:
@@ -90,7 +90,7 @@ paths:
   uk_index: /uk
 
 #Amount of fuzz ImageMagick will use
-fuzz: '20%'
+fuzz: "20%"
 
 #Choose how results are displayed, by default alphanumeric. Different screen widths are always grouped.
 #alphanumeric - all paths (with, and without, a difference) are shown, sorted by path


### PR DESCRIPTION
I found that when trying to get `wraith history` working, I was running into the "unable to find config" error. I had copied & pasted the example history config and still got this issue. I ran the config file through http://www.yamllint.com/ and realized that the problem starts with the string after "directory:" - where it goes from double quotes used earlier in the file to single quotes. When I standardized with double quotes across the whole file, I was able to run wrath successfully. 

This PR is to update the documentation so others might bypass this particular issue.