### PR TITLE
Allow capture without setting selector

### DIFF
--- a/templates/javascript/casper.js
+++ b/templates/javascript/casper.js
@@ -11,7 +11,12 @@ var selector = casper.cli.get(3);
 casper.start(url, function() {
   this.viewport(view_port_width, 1500).then(function(){
     this.wait(2000, function() {
-      this.captureSelector(image_name, selector);
+      if (selector == undefined) {
+        this.capture(image_name);
+      }
+      else {
+        this.captureSelector(image_name, selector);
+      }
       console.log('Snapping ' + url + ' at width ' + view_port_width);
     });
   });


### PR DESCRIPTION
It is a bonus of using CasperJS to be able to target a selector but the user should be able to target the whole page by not choosing a selector.

Below is the example paths values in config.yaml this should also work in component.yaml
```
paths:
  home: /
  uk_index: /uk
```