### PR TITLE
Allow to use spidering in history mode

### DIFF
--- a/lib/wraith/cli.rb
+++ b/lib/wraith/cli.rb
@@ -111,6 +111,7 @@ class Wraith::CLI < Thor
   desc "history [config_name]", "Setup a baseline set of shots"
   def history(config)
     reset_shots(config)
+    check_for_paths(config)
     setup_folders(config)
     save_images(config)
     copy_old_shots(config)


### PR DESCRIPTION
In wraith 2.3.2 when you try to use spidering in history mode you get the following error when running `wraith history config`

```
lib/wraith/folder.rb:24:in `read': No such file or directory - spider.txt (Errno::ENOENT)
from /Users/joseph/Library/Ruby/Gems/1.8/gems/wraith-2.3.2/lib/wraith/folder.rb:24:in `spider_paths'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/wraith-2.3.2/lib/wraith/folder.rb:46:in `create_folders'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/wraith-2.3.2/lib/wraith/cli.rb:41:in `setup_folders'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/wraith-2.3.2/lib/wraith/cli.rb:114:in `history'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
from /Users/joseph/Library/Ruby/Gems/1.8/gems/wraith-2.3.2/bin/wraith:5:in `<top (required)>'
from /Users/joseph/Library/Ruby/Gems/1.8/bin/wraith:23:in `load'
from /Users/joseph/Library/Ruby/Gems/1.8/bin/wraith:23:in `<main>'
```