### PR TITLE
Add missing parameter to GalleryGenerator.new method call

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ task :generate_thumbnails do
 end
 
 task :generate_gallery do
-  gallery = Wraith::GalleryGenerator.new(@config)
+  gallery = Wraith::GalleryGenerator.new(@config, false)
   gallery.generate_gallery
 end
 


### PR DESCRIPTION
Fixes the following error:
```
rake aborted!
wrong number of arguments (1 for 2)
/Users/joseph/repos/wraith/lib/wraith/gallery.rb:15:in `initialize'
/Users/joseph/repos/wraith/Rakefile:61:in `new'
/Users/joseph/repos/wraith/Rakefile:61:in `block in <top (required)>'
```