### PR TITLE
Fix skip links regex

### DIFF
--- a/lib/wraith/spider.rb
+++ b/lib/wraith/spider.rb
@@ -62,7 +62,7 @@ class Wraith::Crawler < Wraith::Spider
       puts "creating new spider file"
       spider_list = []
       Anemone.crawl(@wraith.base_domain) do |anemone|
-        anemone.skip_links_like(/\.#{EXT.join('|')}$/)
+        anemone.skip_links_like(/\.(#{EXT.join('|')})$/)
         # Add user specified skips
         anemone.skip_links_like(@wraith.spider_skips)
         anemone.on_every_page { |page| add_path(page.url.path) }


### PR DESCRIPTION
Use `\.(flv|swf|png|jpg|gif|asx|zip|rar|tar|7z|gz|jar|js|css|dtd|xsd|ico|raw|mp3|mp4|wav|wmv|ape|aac|ac3|wma|aiff|mpg|mpeg|avi|mov|ogg|mkv|mka|asx|asf|mp2|m1v|m3u|f4v|pdf|doc|xls|ppt|pps|bin|exe|rss|xml)$`
instead of `\.flv|swf|png|jpg|gif|asx|zip|rar|tar|7z|gz|jar|js|css|dtd|xsd|ico|raw|mp3|mp4|wav|wmv|ape|aac|ac3|wma|aiff|mpg|mpeg|avi|mov|ogg|mkv|mka|asx|asf|mp2|m1v|m3u|f4v|pdf|doc|xls|ppt|pps|bin|exe|rss|xml$`