### PR TITLE
Initialize history instance variable in SaveMetadata

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -121,8 +121,9 @@ end
 class SaveMetadata
   attr_reader :wraith, :history
 
-  def initialize(config, _history)
+  def initialize(config, history)
     @wraith = config
+    @history = history
   end
 
   def history_label


### PR DESCRIPTION
This pull request fixes a major bug in history mode. In the current version history mode is unusable.

The history instance variable wasn't initialized and in consequence "_latest" wasn't appended to the label. This bug was introduced in "Rubocop refactor" (3d26fbe81dd3361e63f5fda0c72886b55a6b012c).