### PR TITLE
Support screenshot image filenames containing parentheses

### DIFF
--- a/lib/wraith/compare_images.rb
+++ b/lib/wraith/compare_images.rb
@@ -2,6 +2,7 @@ require "wraith"
 require "image_size"
 require "open3"
 require "parallel"
+require "shellwords"
 
 class Wraith::CompareImages
   attr_reader :wraith
@@ -27,7 +28,7 @@ class Wraith::CompareImages
   end
 
   def compare_task(base, compare, output, info)
-    cmdline = "compare -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare} #{output}"
+    cmdline = "compare -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare.shellescape} #{output}"
     px_value = Open3.popen3(cmdline) { |_stdin, _stdout, stderr, _wait_thr| stderr.read }.to_f
     begin
       img_size = ImageSize.path(output).size.inject(:*)

--- a/lib/wraith/crop.rb
+++ b/lib/wraith/crop.rb
@@ -1,6 +1,7 @@
 require "wraith"
 require "image_size"
 require "parallel"
+require "shellwords"
 
 class Wraith::CropImages
   attr_reader :wraith
@@ -32,7 +33,7 @@ class Wraith::CropImages
   end
 
   def crop_task(crop, height, width)
-    `convert #{crop} -background none -extent #{width}x#{height} #{crop}`
+    `convert #{crop.shellescape} -background none -extent #{width}x#{height} #{crop.shellescape}`
   end
 
   def image_dimensions(image)

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -1,5 +1,6 @@
 require "wraith"
 require "parallel"
+require "shellwords"
 
 class Wraith::SaveImages
   attr_reader :wraith, :history, :meta
@@ -73,7 +74,7 @@ class Wraith::SaveImages
   end
 
   def set_image_width(image, width)
-    `convert #{image} -background none -extent #{width}x0 #{image}`
+    `convert #{image.shellescape} -background none -extent #{width}x0 #{image.shellescape}`
   end
 end
 

--- a/lib/wraith/thumbnails.rb
+++ b/lib/wraith/thumbnails.rb
@@ -1,6 +1,7 @@
 require "wraith"
 require "parallel"
 require "fileutils"
+require "shellwords"
 
 class Wraith::Thumbnails
   attr_reader :wraith
@@ -25,6 +26,6 @@ class Wraith::Thumbnails
       FileUtils.mkdir_p(File.dirname(output_path))
     end
 
-    `convert #{png_path} -thumbnail 200 -crop 200x200+0+0 #{output_path}`
+    `convert #{png_path.shellescape} -thumbnail 200 -crop 200x200+0+0 #{output_path.shellescape}`
   end
 end

--- a/spec/wraith_spec.rb
+++ b/spec/wraith_spec.rb
@@ -7,7 +7,7 @@ describe Wraith do
   let(:test_url1) { "http://www.bbc.co.uk/russian" }
   let(:test_url2) { "http://www.bbc.co.uk/russian" }
   let(:test_image1) { "shots/test/test1.png" }
-  let(:test_image2) { "shots/test/test2.png" }
+  let(:test_image2) { "shots/test/test(2).png" }
   let(:diff_image) { "shots/test/test_diff.png" }
   let(:data_txt) { "shots/test/test.txt" }
   let(:selector) { "" }
@@ -94,7 +94,7 @@ describe Wraith do
       Wraith::Thumbnails.new(config_name).generate_thumbnails
 
       expect(File).to exist("shots/thumbnails/test/test1.png")
-      expect(File).to exist("shots/thumbnails/test/test2.png")
+      expect(File).to exist("shots/thumbnails/test/test(2).png")
       expect(File).to exist("shots/thumbnails/test/test_diff.png")
     end
   end


### PR DESCRIPTION
I have a website that has a page with parentheses in its URL. When running e.g. `wraith capture`, cropping the page’s screenshots and generating thumbnails fails with errors like these:

```
cropping images
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `convert shots/__programme__tutt(i)uus/1024__auraco.png -background none -extent 1024x3801 shots/__programme__tutt(i)uus/1024__auraco.png'
cropping images
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `convert shots/__programme__tutt(i)uus/320__auraco.png -background none -extent 320x4202 shots/__programme__tutt(i)uus/320__auraco.png'
...
Generating thumbnails
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `convert shots/__programme__tutt(i)uus/1024__auraco.png -thumbnail 200 -crop 200x200+0+0 shots/thumbnails/__programme__tutt(i)uus/1024__auraco.png'
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `convert shots/__programme__tutt(i)uus/320__auraco.png -thumbnail 200 -crop 200x200+0+0 shots/thumbnails/__programme__tutt(i)uus/320__auraco.png'
```

I solved this by escaping the screenshot filenames before passing them to shell execution. I started writing separate tests for this case too, but in the end I felt it resulted in too much (almost duplicate) test code. So I just test this using the existing tests with an adjusted filename.