### PR TITLE
Don't pass phantomjs options as single command line parameter

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -36,7 +36,7 @@ class Wraith::SaveImages
   end
 
   def capture_page_image(browser, url, width, file_name, selector)
-    puts `"#{browser}" "#{wraith.phantomjs_options}" "#{wraith.snap_file}" "#{url}" "#{width}" "#{file_name}" "#{selector}"`
+    puts `"#{browser}" #{wraith.phantomjs_options} "#{wraith.snap_file}" "#{url}" "#{width}" "#{file_name}" "#{selector}"`
   end
 
   private


### PR DESCRIPTION
This fixes #221 and makes it possible to configure multiple phantomjs parameters like so:
```
phantomjs_options: --ignore-ssl-errors=yes --ssl-protocol=tlsv1
```