### PR TITLE
Change urls to use for a comparison

### DIFF
--- a/templates/configs/config.yaml
+++ b/templates/configs/config.yaml
@@ -11,7 +11,7 @@ directory: 'shots'
 
 # Add only 2 domains, key will act as a label
 domains:
-  english: "http://www.live.bbc.co.uk/news"
+  english: "http://www.bbc.com/news"
   russian: "http://www.live.bbc.co.uk/russian"
 
 #Type screen widths below, here are a couple of examples


### PR DESCRIPTION
The page `http://www.live.bbc.co.uk/news` gives a "This webpage is not available" error.