### PR TITLE
Get the right engine name so that files have complete name

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -131,7 +131,7 @@ class SaveMetadata
   end
 
   def engine_label
-    wraith.engine.key(wraith.engine)
+    wraith.engine.key(engine)
   end
 
   def file_names(width, label, domain_label)


### PR DESCRIPTION
I've found that names were ```1024__english.png``` instead of ```1024_phantomjs_english.png```.

This PR should address that problem.