### PR TITLE
Added word breaks for loooong words in gallery sidebar

### DIFF
--- a/lib/wraith/gallery_template/gallery_template.erb
+++ b/lib/wraith/gallery_template/gallery_template.erb
@@ -6,6 +6,9 @@
         .short-screenshot {
           max-width: 200px;
         }
+        .panel li{
+          word-wrap: break-word;
+        }
       </style>
     </head>
     <body>


### PR DESCRIPTION
Suggested solution for text in the left sidebar overlapping the page as mentioned by @eyal919 here: https://github.com/BBC-News/wraith/issues/265