### PR TITLE
more user-friendly error message

### DIFF
--- a/lib/wraith/folder.rb
+++ b/lib/wraith/folder.rb
@@ -34,7 +34,11 @@ class Wraith::FolderManager
   end
 
   def copy_old_shots
-    FileUtils.cp_r("#{dir}/.", "#{history_dir}/")
+    if history_dir.nil?
+      abort 'Error: no `history_dir` attribute found in config. Cannot copy files.'
+    else
+      FileUtils.cp_r("#{dir}/.", "#{history_dir}/")
+    end
   end
 
   def restore_shots


### PR DESCRIPTION
more user-friendly error message for people who forget to specify `history_dir`.

I realise this isn't much of a PR, just getting a feeler for how Wraith works, etc. Making a small contribution :)