### PR TITLE
Using not operator instead double equal, to avoid error in casperjs

### DIFF
--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -11,7 +11,7 @@ var globalBeforeCaptureJS = casper.cli.get(4);
 var pathBeforeCaptureJS = casper.cli.get(5);
 
 function snap() {
-  if (selector == undefined) {
+  if (!selector) {
     this.capture(image_name);
   }
   else {


### PR DESCRIPTION
I'm catching an error when running wraith in development because in this line the `selector` variable is `false` instead `undefined`, once I don't define a selector to my (dynamic) paths. 

This change has the same effects, but I don't know if it could generates an unknown side effect, so feel free to close this pull request.

The log error:
```
CasperError: No element matching selector found: false
  /Users/marciovicente/git/repo:832 in getElementBounds
  /Users/marciovicente/git/repo:316 in captureSelector
  /Users/marciovicente/git/repo/javascript/casper.js:18 in snap
  /Users/marciovicente/.rvm/gems/ruby-2.1.3/gems/casperjs-1.0.0/bin/bootstrap.js:52
  /Users/marciovicente/git/repo/javascript/casper.js:45 in then
  /Users/marciovicente/git/repo:1326 in runStep
  /Users/marciovicente/git/repo:332 in checkStep
Failed to capture image shots/dropdown/1280_phantomjs_default.png on attempt number 5 of 5
Unable to capture image shots/dropdown/1280_phantomjs_default.png after 5 attempt(s)
```

My config file:
```
#Headless browser option
browser:
  phantomjs: "casperjs"

#If you want to have multiple snapping files, set the file name here
snap_file: "javascript/casper.js"

# Type the name of the directory that shots will be stored in
directory: "shots"
history_dir: "shots_history"

# Add only 2 domains, key will act as a label
domains:
  default: "http://localhost:8040"

#Type screen widths below, here are a couple of examples
screen_widths:
  - 320
  - 1280

#Amount of fuzz ImageMagick will use
fuzz: '20%'

# spider_file: spider-test.txt

#Set the number of days to keep the site spider file
spider_days:
  - 10

#Choose how results are displayed, by default alphanumeric. Different screen widths are always grouped.
#alphanumeric - all paths (with, and without, a difference) are shown, sorted by path
#diffs_first - all paths (with, and without, a difference) are shown, sorted by difference size (largest first)
#diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
mode: diffs_first

threshold: 5
```