### PR TITLE
Efficient mode (debug)

### DIFF
--- a/lib/wraith/javascript/_getDimensions.js
+++ b/lib/wraith/javascript/_getDimensions.js
@@ -9,7 +9,7 @@ module.exports = function (dimensions) {
         };
     }
 
-    var multipleDimensions = dimensions.split(' ');
+    var multipleDimensions = dimensions.split(',');
 
     if (multipleDimensions.length > 1) {
         return multipleDimensions.map(function (dimensions) {

--- a/lib/wraith/javascript/_getDimensions.js
+++ b/lib/wraith/javascript/_getDimensions.js
@@ -1,5 +1,6 @@
 module.exports = function (dimensions) {
-    dimensions = '' + dimensions; // cast to string
+    // remove quotes from dimensions string
+    dimensions = dimensions.replace(/'/gi, '');
 
     function getWidthAndHeight(dimensions) {
         dimensions = /(\d*)x?((\d*))?/i.exec(dimensions);

--- a/lib/wraith/javascript/_getDimensions.js
+++ b/lib/wraith/javascript/_getDimensions.js
@@ -1,7 +1,22 @@
 module.exports = function (dimensions) {
-    dimensions = /(\d*)x?((\d*))?/i.exec(dimensions);
-    return {
-        'viewportWidth':  parseInt(dimensions[1]),
-        'viewportHeight': parseInt(dimensions[2] || 1500)
-    };
+    dimensions = '' + dimensions; // cast to string
+
+    function getWidthAndHeight(dimensions) {
+        dimensions = /(\d*)x?((\d*))?/i.exec(dimensions);
+        return {
+            'viewportWidth':  parseInt(dimensions[1]),
+            'viewportHeight': parseInt(dimensions[2] || 1500)
+        };
+    }
+
+    var multipleDimensions = dimensions.split(' ');
+
+    if (multipleDimensions.length > 1) {
+        return multipleDimensions.map(function (dimensions) {
+            return getWidthAndHeight(dimensions);
+        });
+    }
+    else {
+        return getWidthAndHeight(dimensions);
+    }
 }

--- a/lib/wraith/javascript/_phantom__common.js
+++ b/lib/wraith/javascript/_phantom__common.js
@@ -13,7 +13,9 @@ module.exports = function (config) {
       image_name = systemArgs[3],
       selector   = systemArgs[4],
       globalBeforeCaptureJS = systemArgs[5],
-      pathBeforeCaptureJS = systemArgs[6];
+      pathBeforeCaptureJS = systemArgs[6],
+      dimensionsProcessed = 0,
+      currentDimensions;
 
   globalBeforeCaptureJS = globalBeforeCaptureJS === 'false' ? false : globalBeforeCaptureJS;
   pathBeforeCaptureJS   = pathBeforeCaptureJS === 'false' ? false : pathBeforeCaptureJS;
@@ -22,7 +24,15 @@ module.exports = function (config) {
   var last_request_timeout;
   var final_timeout;
 
-  page.viewportSize = { width: dimensions.viewportWidth, height: dimensions.viewportHeight};
+  if (takingMultipleScreenshots()) {
+    currentDimensions = dimensions[0];
+    image_name = replaceImageNameWithDimensions(image_name, currentDimensions);
+  }
+  else {
+    currentDimensions = dimensions;
+  }
+
+  page.viewportSize = { width: currentDimensions.viewportWidth, height: currentDimensions.viewportHeight};
   page.settings = { loadImages: true, javascriptEnabled: javascriptEnabled };
 
   // If you want to use additional phantomjs commands, place them here
@@ -66,6 +76,56 @@ module.exports = function (config) {
     }
   });
 
+  function takingMultipleScreenshots() {
+    return dimensions.length && dimensions.length > 1;
+  }
+
+  function replaceImageNameWithDimensions(image_name, currentDimensions) {
+    // shots/clickable_guide__after_click/MULTI_casperjs_english.png
+    // ->
+    // shots/clickable_guide__after_click/1024x359_casperjs_english.png
+    var dirs = image_name.split('/'),
+        filename = dirs[dirs.length - 1],
+        filenameParts = filename.split('_'),
+        newFilename;
+
+    filenameParts[0] = currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight;
+    dirs.pop(); // remove MULTI_casperjs_english.png
+    newFilename = dirs.join('/') + '/' + filenameParts.join('_');
+    return newFilename;
+  }
+
+  function runSetupJavaScriptThenCaptureImage() {
+    if (globalBeforeCaptureJS) {
+      require(globalBeforeCaptureJS)(page);
+    }
+    if (pathBeforeCaptureJS) {
+      require(pathBeforeCaptureJS)(page);
+    }
+    captureImage();
+  }
+
+  function captureImage() {
+
+    console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
+    page.clipRect = {
+      top: 0,
+      left: 0,
+      height: currentDimensions.viewportHeight,
+      width: currentDimensions.viewportWidth
+    };
+    page.render(image_name);
+
+    dimensionsProcessed++;
+    if (takingMultipleScreenshots() && dimensionsProcessed < dimensions.length) {
+      currentDimensions = dimensions[dimensionsProcessed];
+      image_name = replaceImageNameWithDimensions(image_name, currentDimensions);
+      setTimeout(captureImage, 1000);
+    }
+    else {
+      phantom.exit();
+    }
+  }
 
   function debounced_render() {
     clearTimeout(last_request_timeout);
@@ -75,48 +135,12 @@ module.exports = function (config) {
     // rendering, just in case the page kicks off another request
     if (current_requests < 1) {
       clearTimeout(final_timeout);
-      last_request_timeout = setTimeout(function() {
-
-          if (globalBeforeCaptureJS) {
-            require(globalBeforeCaptureJS)(page);
-          }
-          if (pathBeforeCaptureJS) {
-            require(pathBeforeCaptureJS)(page);
-          }
-
-          console.log('Snapping ' + url + ' at: ' + dimensions.viewportWidth + 'x' + dimensions.viewportHeight);
-          page.clipRect = {
-            top: 0,
-            left: 0,
-            height: dimensions.viewportHeight,
-            width: dimensions.viewportWidth
-          };
-          page.render(image_name);
-          phantom.exit();
-      }, 1000);
+      last_request_timeout = setTimeout(runSetupJavaScriptThenCaptureImage, 1000);
     }
 
     // Sometimes, straggling requests never make it back, in which
     // case, timeout after 5 seconds and render the page anyway
-    final_timeout = setTimeout(function() {
-
-      if (globalBeforeCaptureJS) {
-        require(globalBeforeCaptureJS)(page);
-      }
-      if (pathBeforeCaptureJS) {
-        require(pathBeforeCaptureJS)(page);
-      }
-
-      console.log('Snapping ' + url + ' at: ' + dimensions.viewportWidth + 'x' + dimensions.viewportHeight);
-      page.clipRect = {
-        top: 0,
-        left: 0,
-        height: dimensions.viewportHeight,
-        width: dimensions.viewportWidth
-      };
-      page.render(image_name);
-      phantom.exit();
-    }, 5000);
+    final_timeout = setTimeout(runSetupJavaScriptThenCaptureImage, 5000);
   }
 
 }

--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -26,13 +26,14 @@ function requireRelative(file) {
   return require(currentFilePath + '/' + file);
 }
 function snap() {
+  console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
+
   if (!selector) {
     this.capture(image_name);
   }
   else {
     this.captureSelector(image_name, selector);
   }
-  console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
 
   dimensionsProcessed++;
   if (takingMultipleScreenshots() && dimensionsProcessed < dimensions.length) {
@@ -45,22 +46,23 @@ function snap() {
   }
 }
 function replaceImageNameWithDimensions(image_name, currentDimensions) {
-  // shots/clickable_guide__after_click/600x768_casperjs_english.png
+  // shots/clickable_guide__after_click/MULTI_casperjs_english.png
   // ->
-  // shots/clickable_guide__after_click/1024_casperjs_english.png
+  // shots/clickable_guide__after_click/1024x359_casperjs_english.png
   var dirs = image_name.split('/'),
       filename = dirs[dirs.length - 1],
       filenameParts = filename.split('_'),
       newFilename;
 
   filenameParts[0] = currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight;
-  dirs.pop(); // remove 600x768_casperjs_english.png
+  dirs.pop(); // remove MULTI_casperjs_english.png
   newFilename = dirs.join('/') + '/' + filenameParts.join('_');
   return newFilename;
 }
 
 if (takingMultipleScreenshots()) {
   currentDimensions = dimensions[0];
+  image_name = replaceImageNameWithDimensions(image_name, currentDimensions);
 }
 else {
   currentDimensions = dimensions;

--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -8,9 +8,14 @@ var url = casper.cli.get(0),
     image_name = casper.cli.get(2),
     selector = casper.cli.get(3),
     globalBeforeCaptureJS = casper.cli.get(4),
-    pathBeforeCaptureJS = casper.cli.get(5);
+    pathBeforeCaptureJS = casper.cli.get(5),
+    dimensionsProcessed = 0,
+    currentDimensions;
 
 // functions
+function takingMultipleScreenshots() {
+  return dimensions.length && dimensions.length > 1;
+}
 function requireRelative(file) {
   // PhantomJS will automatically `require` relatively, but CasperJS needs some extra help. Hence this function.
   // 'templates/javascript/casper.js' -> 'templates/javascript'
@@ -27,13 +32,44 @@ function snap() {
   else {
     this.captureSelector(image_name, selector);
   }
-  console.log('Snapping ' + url + ' at: ' + dimensions.viewportWidth + 'x' + dimensions.viewportHeight);
+  console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
+
+  dimensionsProcessed++;
+  if (takingMultipleScreenshots() && dimensionsProcessed < dimensions.length) {
+    currentDimensions = dimensions[dimensionsProcessed];
+    image_name = replaceImageNameWithDimensions(image_name, currentDimensions);
+    casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeight);
+    casper.wait(300, function then () {
+      snap.bind(this)();
+    });
+  }
+}
+function replaceImageNameWithDimensions(image_name, currentDimensions) {
+  // shots/clickable_guide__after_click/600x768_casperjs_english.png
+  // ->
+  // shots/clickable_guide__after_click/1024_casperjs_english.png
+  var dirs = image_name.split('/'),
+      filename = dirs[dirs.length - 1],
+      filenameParts = filename.split('_'),
+      newFilename;
+
+  filenameParts[0] = currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight;
+  dirs.pop(); // remove 600x768_casperjs_english.png
+  newFilename = dirs.join('/') + '/' + filenameParts.join('_');
+  return newFilename;
+}
+
+if (takingMultipleScreenshots()) {
+  currentDimensions = dimensions[0];
+}
+else {
+  currentDimensions = dimensions;
 }
 
 // Casper can now do its magic
 casper.start();
 casper.open(url);
-casper.viewport(dimensions.viewportWidth, dimensions.viewportHeight);
+casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeight);
 casper.then(function() {
   if (globalBeforeCaptureJS) {
     require('./' + globalBeforeCaptureJS)(this);

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -37,7 +37,10 @@ class Wraith::SaveImages
   end
 
   def capture_page_image(browser, url, width, file_name, selector, global_before_capture, path_before_capture)
-    command = "#{browser} #{wraith.phantomjs_options} '#{wraith.snap_file}' '#{url}' '#{width}' '#{file_name}' '#{selector}' '#{global_before_capture}' '#{path_before_capture}'"
+
+    width = "320 464x900 768" # temporarily mocking the array passing behaviour in shell
+
+    command = "#{browser} #{wraith.phantomjs_options} '#{wraith.snap_file}' '#{url}' \"'#{width}'\" '#{file_name}' '#{selector}' '#{global_before_capture}' '#{path_before_capture}'"
 
     # @TODO - uncomment the following line when we add a verbose mode
     # puts command

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -26,9 +26,8 @@ class Wraith::SaveImages
       settings = CaptureOptions.new(options, wraith)
 
       if wraith.resize
-        jobs = define_jobs(label, settings, wraith.widths)
+        jobs = jobs + define_jobs(label, settings, wraith.widths)
       else
-        jobs = []
         wraith.widths.each do |width|
           jobs = jobs + define_jobs(label, settings, width)
         end
@@ -58,7 +57,7 @@ class Wraith::SaveImages
     command = "#{browser} #{wraith.phantomjs_options} '#{wraith.snap_file}' '#{url}' \"#{width}\" '#{file_name}' '#{selector}' '#{global_before_capture}' '#{path_before_capture}'"
 
     # @TODO - uncomment the following line when we add a verbose mode
-    puts command
+    #puts command
     run_command command
   end
 

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -62,6 +62,10 @@ class Wraith::Wraith
     @config["screen_widths"]
   end
 
+  def resize
+    @config["resize_or_reload"] ? (@config["resize_or_reload"] == "resize") : true
+  end
+
   def domains
     @config["domains"]
   end

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -63,7 +63,8 @@ class Wraith::Wraith
   end
 
   def resize
-    @config["resize_or_reload"] ? (@config["resize_or_reload"] == "resize") : true
+    # @TODO make this default to true, once it's been tested a bit more thoroughly
+    @config["resize_or_reload"] ? (@config["resize_or_reload"] == "resize") : false
   end
 
   def domains

--- a/templates/configs/component.yaml
+++ b/templates/configs/component.yaml
@@ -34,6 +34,9 @@ screen_widths:
   - 1024
   - 1280
 
+# resize to each screen width, or reload at each screen width. (The former is more efficient).
+resize_or_reload: 'resize'
+
 # the engine to run Wraith with.
 browser: "casperjs"
 


### PR DESCRIPTION
PR to merge into `develop` branch. Essentially working, but *still needs tests*.

Basically changes the jobs batch, from this:

```
[
["clickable_guide__after_click", "/news/entertainment-arts-27221191", 320, "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/320_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"],
["clickable_guide__after_click", "/news/entertainment-arts-27221191", "600x768", "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/600x768_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"],
["clickable_guide__after_click", "/news/entertainment-arts-27221191", 768, "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/768_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"],
["clickable_guide__after_click", "/news/entertainment-arts-27221191", 1024, "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/1024_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"],
["clickable_guide__after_click", "/news/entertainment-arts-27221191", 1280, "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/1280_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"]
]
```

to this:

```
[
["clickable_guide__after_click", "/news/entertainment-arts-27221191", ['320', '600x768', '768', '1024', '1280'], "http://www.bbc.co.uk/news/entertainment-arts-27221191", "shots/clickable_guide__after_click/[320, \"600x768\", 768, 1024, 1280]_casperjs_english.png", ".idt__news", "false", "javascript/beforeCapture--casper_example.js"]
]
```