### PR TITLE
Before capture pathfix

### DIFF
--- a/lib/wraith/javascript/_phantom__common.js
+++ b/lib/wraith/javascript/_phantom__common.js
@@ -89,7 +89,7 @@ module.exports = function (config) {
       // see https://github.com/n1k0/casperjs/issues/1068
       setTimeout(function(){
         phantom.exit();
-      }, 10);
+      }, 30);
     }
   }
 

--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -58,12 +58,12 @@ casper.open(url);
 casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeight);
 casper.then(function() {
   if (globalBeforeCaptureJS) {
-    require('./' + globalBeforeCaptureJS)(this);
+    require(globalBeforeCaptureJS)(this);
   }
 });
 casper.then(function() {
   if (pathBeforeCaptureJS) {
-    require('./' + pathBeforeCaptureJS)(this);
+    require(pathBeforeCaptureJS)(this);
   }
 });
 // waits for all images to download before taking screenshots

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -1,6 +1,7 @@
 require "wraith"
 require "parallel"
 require "shellwords"
+require "wraith/utilities"
 
 class Wraith::SaveImages
   attr_reader :wraith, :history, :meta
@@ -135,7 +136,7 @@ class CaptureOptions
   end
 
   def before_capture
-    options["before_capture"] || "false"
+    @options["before_capture"] ? convert_to_absolute(@options["before_capture"]) : "false"
   end
 
   def base_url

--- a/lib/wraith/utilities.rb
+++ b/lib/wraith/utilities.rb
@@ -1,0 +1,12 @@
+# @TODO - extract more shared functions to this file
+
+def convert_to_absolute(filepath)
+  if filepath[0] == '/'
+    # filepath is already absolute. return unchanged
+    filepath
+  else
+    # filepath is relative. it must be converted to absolute
+    working_dir = `pwd`.chomp
+    "#{working_dir}/#{filepath}"
+  end
+end

--- a/lib/wraith/version.rb
+++ b/lib/wraith/version.rb
@@ -1,3 +1,3 @@
 module Wraith
-  VERSION = "2.8.1"
+  VERSION = "3.0.0"
 end

--- a/lib/wraith/version.rb
+++ b/lib/wraith/version.rb
@@ -1,3 +1,3 @@
 module Wraith
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "wraith/utilities"
 
 class Wraith::Wraith
   attr_accessor :config
@@ -41,17 +42,6 @@ class Wraith::Wraith
     @config["snap_file"] ? convert_to_absolute(@config["snap_file"]) : snap_file_from_engine(engine)
   end
 
-  def convert_to_absolute(filepath)
-    if filepath[0] == '/'
-      # filepath is already absolute. return unchanged
-      filepath
-    else
-      # filepath is relative. it must be converted to absolute
-      working_dir = `pwd`.chomp
-      "#{working_dir}/#{filepath}"
-    end
-  end
-
   def snap_file_from_engine(engine)
     path_to_js_templates = File.dirname(__FILE__) + '/javascript'
     case engine
@@ -66,7 +56,7 @@ class Wraith::Wraith
   end
 
   def before_capture
-    @config["before_capture"] || "false"
+    @config["before_capture"] ? convert_to_absolute(@config["before_capture"]) : "false"
   end
 
   def widths

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -38,7 +38,18 @@ class Wraith::Wraith
   end
 
   def snap_file
-    @config["snap_file"] || snap_file_from_engine(engine)
+    @config["snap_file"] ? convert_to_absolute(@config["snap_file"]) : snap_file_from_engine(engine)
+  end
+
+  def convert_to_absolute(filepath)
+    if filepath[0] == '/'
+      # filepath is already absolute. return unchanged
+      filepath
+    else
+      # filepath is relative. it must be converted to absolute
+      working_dir = `pwd`.chomp
+      "#{working_dir}/#{filepath}"
+    end
   end
 
   def snap_file_from_engine(engine)

--- a/spec/before_capture_spec.rb
+++ b/spec/before_capture_spec.rb
@@ -11,6 +11,29 @@ describe Wraith do
   let(:before_suite_js) { "spec/js/global.js" }
   let(:before_capture_js) { "spec/js/path.js" }
 
+  describe "different ways of determining the before_capture file" do
+    it "should allow users to specify the relative path to the before_capture file" do
+      config = YAML.load '
+        browser:        casperjs
+        before_capture: javascript/do_something.js
+      '
+      wraith = Wraith::Wraith.new(config, true)
+      # not sure about having code IN the test, but we want to get this right.
+      expect(wraith.before_capture).to eq (`pwd`.chomp! + '/javascript/do_something.js')
+    end
+
+    it "should allow users to specify the absolute path to the before_capture file" do
+      config = YAML.load '
+        browser:        casperjs
+        before_capture: /Users/some_user/wraith/javascript/do_something.js
+      '
+      wraith = Wraith::Wraith.new(config, true)
+      expect(wraith.before_capture).to eq ('/Users/some_user/wraith/javascript/do_something.js')
+    end
+  end
+
+  # @TODO - we need tests determining the path to "path-level before_capture hooks"
+
   describe "When hooking into beforeCapture (CasperJS)" do
 
     it "Executes the global JS before capturing" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -110,13 +110,23 @@ describe "wraith config" do
       expect(wraith.snap_file).to include 'lib/wraith/javascript/casper.js'
     end
 
-    it "should allow users to specify their own snap file" do
+    it "should allow users to specify the relative path to their own snap file" do
       config = YAML.load '
         browser:   casperjs
         snap_file: path/to/snap.js
       '
       wraith = Wraith::Wraith.new(config, true)
-      expect(wraith.snap_file).to eq 'path/to/snap.js'
+      # not sure about having code IN the test, but we want to get this right.
+      expect(wraith.snap_file).to eq (`pwd`.chomp! + '/path/to/snap.js')
+    end
+
+    it "should allow users to specify the absolute path to their own snap file" do
+      config = YAML.load '
+        browser:   casperjs
+        snap_file: /Users/my_username/Sites/bbc/wraith/path/to/snap.js
+      '
+      wraith = Wraith::Wraith.new(config, true)
+      expect(wraith.snap_file).to eq ('/Users/my_username/Sites/bbc/wraith/path/to/snap.js')
     end
   end
 


### PR DESCRIPTION
Fixes #338 - making sure that `before_capture` is made absolute before it is passed to Casper/Phantom.