### PR TITLE
Bug fixes for 3.0.1

### DIFF
--- a/lib/wraith/javascript/_helper.js
+++ b/lib/wraith/javascript/_helper.js
@@ -1,4 +1,6 @@
 module.exports = function (commandLineDimensions) {
+
+    commandLineDimensions = '' + commandLineDimensions; // cast to string
     // remove quotes from dimensions string
     commandLineDimensions = commandLineDimensions.replace(/'/gi, '');
 

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -31,7 +31,7 @@ class Wraith::SaveImages
     check_paths.each do |label, options|
       settings = CaptureOptions.new(options, wraith)
 
-      if wraith.resize
+      if settings.resize
         jobs = jobs + define_individual_job(label, settings, wraith.widths)
       else
         wraith.widths.each do |width|
@@ -66,7 +66,7 @@ class Wraith::SaveImages
     command = "#{browser} #{wraith.phantomjs_options} '#{wraith.snap_file}' '#{url}' \"#{width}\" '#{file_name}' '#{selector}' '#{global_before_capture}' '#{path_before_capture}'"
 
     # @TODO - uncomment the following line when we add a verbose mode
-    #puts command
+    # puts command
     run_command command
   end
 
@@ -132,7 +132,16 @@ class CaptureOptions
   end
 
   def selector
-    options["selector"] || " "
+    options["selector"] || "body"
+  end
+
+  def resize
+    # path level, or YAML-file level `resize_or_reload` property value
+    if @options["resize_or_reload"]
+      (@options["resize_or_reload"] == 'resize')
+    else
+      @wraith.resize
+    end
   end
 
   def before_capture

--- a/lib/wraith/version.rb
+++ b/lib/wraith/version.rb
@@ -1,3 +1,3 @@
 module Wraith
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
Attempting to fix #341. This seems to have worked with one line: https://github.com/BBC-News/wraith/pull/342/files#diff-0e8c6c0c13e582f09b10349333af46c0R3

Other than fixing the bugs, this also augments the `resize_or_reload` property so that it applies either at the file level or the path level, so that you can override `resize_or_reload` for specific paths (e.g. pages that respond differently on page load depending on viewport size). *This needs a corresponding test*.