### PR TITLE
Consistently capitalize GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,9 +91,9 @@
               <h1>Wraith</h1>
               <p>A responsive screenshot comparison tool</p>
               <br>
-              <p>The project is hosted on <a class="projectLinks" href="https://github.com/BBC-News/wraith" target="_blank">Github</a> and is available for use under the <a class="projectLinks" href="https://github.com/BBC-News/wraith/blob/master/LICENSE" target="_blank">Apache 2.0 open source license</a>.  You can report bugs and discuss features on the <a href="https://github.com/BBC-News/wraith/issues?state=open" target="_blank">GitHub issues page</a>, or send tweets to <a href="https://twitter.com/ResponsiveNews" target="_blank">@ResponsiveNews</a>.
+              <p>The project is hosted on <a class="projectLinks" href="https://github.com/BBC-News/wraith" target="_blank">GitHub</a> and is available for use under the <a class="projectLinks" href="https://github.com/BBC-News/wraith/blob/master/LICENSE" target="_blank">Apache 2.0 open source license</a>.  You can report bugs and discuss features on the <a href="https://github.com/BBC-News/wraith/issues?state=open" target="_blank">GitHub issues page</a>, or send tweets to <a href="https://twitter.com/ResponsiveNews" target="_blank">@ResponsiveNews</a>.
               </p>
-              <p><a class="btn btn-primary btn-lg" href="https://github.com/BBC-News/wraith" target="_blank">Fork on Github »</a></p>
+              <p><a class="btn btn-primary btn-lg" href="https://github.com/BBC-News/wraith" target="_blank">Fork on GitHub »</a></p>
             </div>
           </div>
 


### PR DESCRIPTION
- "GitHub" is its correct capitalization, so here's a PR. :sunny: