### PR TITLE
Add a version command

### DIFF
--- a/lib/wraith/cli.rb
+++ b/lib/wraith/cli.rb
@@ -176,4 +176,9 @@ class Wraith::CLI < Thor
       generate_gallery(config)
     end
   end
+
+  desc "version", "Show the version of wraith"
+  def version
+    puts "Wraith version " + Wraith::VERSION
+  end
 end

--- a/lib/wraith/cli.rb
+++ b/lib/wraith/cli.rb
@@ -177,8 +177,9 @@ class Wraith::CLI < Thor
     end
   end
 
-  desc "version", "Show the version of wraith"
+  desc "version", "Show the version of Wraith"
+  map ["--version", "-version", "-v"] => "version"
   def version
-    puts "Wraith version " + Wraith::VERSION
+    logger.info Wraith::VERSION
   end
 end


### PR DESCRIPTION
Adds a version command to Wraith.  Fix for #397.

When the command ‘wraith version’ is run it will output ‘Wraith version X.X.X’