### PR TITLE
Fix #298 - use the latest version of ImageMagick with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN echo "deb http://security.debian.org/ jessie/updates contrib non-free" | tee
 RUN apt-get update
 RUN apt-get install -y ttf-freefont ttf-mscorefonts-installer ttf-bitstream-vera ttf-dejavu ttf-liberation
 
+# Make sure a recent (>6.7.7-10) version of ImageMagick is installed.
+RUN apt-get install -y imagemagick
+
 ENTRYPOINT [ "wraith" ]


### PR DESCRIPTION
I ran some tests and found #298 resolved in ImageMagick versions 6.8.9-9 and higher. The Dockerfile was using 6.7.7-10, so I've updated it to install a more recent version.