### PR TITLE
Use more threads for saving images

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -73,7 +73,7 @@ class Wraith::SaveImages
   end
 
   def parallel_task(jobs)
-    Parallel.each(jobs, :in_threads => 8) do |_label, _path, width, url, filename, selector, global_before_capture, path_before_capture|
+    Parallel.each(jobs, :in_threads => Parallel.processor_count) do |_label, _path, width, url, filename, selector, global_before_capture, path_before_capture|
       begin
         command = construct_command(width, url, filename, selector, global_before_capture, path_before_capture)
         attempt_image_capture(command, filename)


### PR DESCRIPTION
Previously we had 8 threads hardcoded to perform the saving of images.
For a set of 600 paths this took around 10 minutes on a 32 core machine.
Updating the thread count to match the number of cores our processor
resulted in a 3.5 minute runtime for the same set of paths.

This change should also help performance on machines with less than
eight cores as we'll have less communication overhead and saving an
image consumes an entire CPU core anyways.