### PR TITLE
Add config option to set threads for saving images

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -73,7 +73,7 @@ class Wraith::SaveImages
   end
 
   def parallel_task(jobs)
-    Parallel.each(jobs, :in_threads => 8) do |_label, _path, width, url, filename, selector, global_before_capture, path_before_capture|
+    Parallel.each(jobs, :in_threads => wraith.save_image_threads) do |_label, _path, width, url, filename, selector, global_before_capture, path_before_capture|
       begin
         command = construct_command(width, url, filename, selector, global_before_capture, path_before_capture)
         attempt_image_capture(command, filename)

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -171,4 +171,8 @@ class Wraith::Wraith
     # @TODO - also add a `--verbose` CLI flag which overrides whatever you have set in the config
     @config["verbose"] || false
   end
+
+  def save_image_threads
+    (@config["save_image_threads"] || 8).to_i
+  end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -66,6 +66,10 @@ describe "wraith config" do
     it "include compare label" do
       expect(wraith.paths).to eq("home" => "/", "uk_index" => "/uk")
     end
+
+    it "include save image threads" do
+      expect(wraith.save_image_threads).to eq(7)
+    end
   end
 
   describe "different ways of initialising browser engine" do

--- a/spec/configs/test_config--casper.yaml
+++ b/spec/configs/test_config--casper.yaml
@@ -28,3 +28,6 @@ paths:
 
 #Amount of fuzz ImageMagick will use
 fuzz: '20%'
+
+# Number of threads used when saving images
+save_image_threads: 7

--- a/spec/configs/test_config--phantom.yaml
+++ b/spec/configs/test_config--phantom.yaml
@@ -32,3 +32,7 @@ paths:
 
 #Amount of fuzz ImageMagick will use
 fuzz: '20%'
+
+
+# Number of threads used when saving images
+save_image_threads: 7

--- a/templates/configs/capture.yaml
+++ b/templates/configs/capture.yaml
@@ -59,3 +59,7 @@ gallery:
 #   diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
 # Note: different screen widths are always grouped together.
 mode: diffs_first
+
+# (optional) Set the number of threads to use when saving images. Raising this value can improve performance, but very high
+# values can lead to server connection issues. Set to around 1.5 the available CPU cores for best performance. Default: 8
+save_image_threads: 8

--- a/templates/configs/history.yaml
+++ b/templates/configs/history.yaml
@@ -79,3 +79,7 @@ highlight_color: red
 
 # (optional) Parameters to pass to Phantom/Casper command line. Default: '--ignore-ssl-errors=true --ssl-protocol=tlsv1'
 phantomjs_options: ''
+
+# (optional) Set the number of threads to use when saving images. Raising this value can improve performance, but very high
+# values can lead to server connection issues. Set to around 1.5 the available CPU cores for best performance. Default: 8
+save_image_threads: 8

--- a/templates/configs/spider.yaml
+++ b/templates/configs/spider.yaml
@@ -58,3 +58,7 @@ directory: 'shots'
 #   diffs_first - all paths (with or without a difference) are shown, sorted by difference size (largest first)
 #   diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
 mode: diffs_first
+
+# (optional) Set the number of threads to use when saving images. Raising this value can improve performance, but very high
+# values can lead to server connection issues. Set to around 1.5 the available CPU cores for best performance. Default: 8
+save_image_threads: 8


### PR DESCRIPTION
In testing i've found that using around 1.5 times the CPU cores
available on a machine yields the best performance with saving images.

This is really important on machines with a lot of cores, we use 32 core
machines in our tests and using up all the cores cuts down wraith time
in half.

8 seems like a good default, this PR adds the ability to change the
value.
