### PR TITLE
Updated Dockerfile to install the new phantomjs and casperjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM ruby:2.1.2
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
 RUN apt-get update
-RUN curl -o phantomjs.tar.gz -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2
-RUN tar -xvf phantomjs.tar.gz
-RUN mv phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/bin
 RUN echo "export phantomjs=/usr/bin/phantomjs" > .bashrc
-RUN apt-get install -y libfreetype6 libfontconfig1
+RUN apt-get install -y libfreetype6 libfontconfig1 nodejs npm
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN npm install npm
+RUN npm install -g phantomjs@2.1.7 casperjs@1.1.1
 RUN gem install wraith --no-rdoc --no-ri
 RUN gem install aws-sdk --no-rdoc --no-ri
 


### PR DESCRIPTION
Fixes issue with wraith not being able to run in Docker because casperjs is not installed.
Also fixes #436 and updates phantomjs.

Installs node so we can use npm to install phantomjs and casperjs.

Doesn't install phantomjs 1.9.8 and instead installs phantomjs 2.1.7.
Also installs casperjs 1.1.1.