### PR TITLE
Fix "undefined local variable or method `wraith'"

### DIFF
--- a/lib/wraith/spider.rb
+++ b/lib/wraith/spider.rb
@@ -27,6 +27,8 @@ class Wraith::Spidering
 end
 
 class Wraith::Spider
+  attr_reader :wraith
+
   def initialize(wraith)
     @wraith = wraith
     @paths = {}


### PR DESCRIPTION
Add attr_reader to Wraith::Spider to fix error "undefined local variable or method `wraith'"

resolves #401, #422