### PR TITLE
add target url as parameter to beforeCaptureJS

### DIFF
--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -59,15 +59,16 @@ casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeigh
 casper.then(function() {
   var self = this;
   if (globalBeforeCaptureJS && pathBeforeCaptureJS) {
-    require(globalBeforeCaptureJS)(self, function thenExecuteOtherBeforeCaptureFile() {
-      require(pathBeforeCaptureJS)(self, captureImage);
-    });
+    var thenExecuteOtherBeforeCaptureFile = function() {
+      require(pathBeforeCaptureJS)(self, captureImage, url);
+    };
+    require(globalBeforeCaptureJS)(self, thenExecuteOtherBeforeCaptureFile, url);
   }
   else if (globalBeforeCaptureJS) {
-    require(globalBeforeCaptureJS)(self, captureImage);
+    require(globalBeforeCaptureJS)(self, captureImage, url);
   }
   else if (pathBeforeCaptureJS) {
-    require(pathBeforeCaptureJS)(self, captureImage);
+    require(pathBeforeCaptureJS)(self, captureImage, url);
   }
   else {
     captureImage();

--- a/lib/wraith/javascript/phantom.js
+++ b/lib/wraith/javascript/phantom.js
@@ -95,15 +95,16 @@ function markPageAsLoaded() {
 function runSetupJavaScriptThen(callback) {
   setupJavaScriptRan = true;
   if (globalBeforeCaptureJS && pathBeforeCaptureJS) {
-    require(globalBeforeCaptureJS)(page, function thenExecuteOtherBeforeCaptureFile() {
+    var thenExecuteOtherBeforeCaptureFile = function () {
       require(pathBeforeCaptureJS)(page, callback);
-    });
+    };
+    require(globalBeforeCaptureJS)(page, thenExecuteOtherBeforeCaptureFile, url);
   }
   else if (globalBeforeCaptureJS) {
-    require(globalBeforeCaptureJS)(page, callback);
+    require(globalBeforeCaptureJS)(page, callback, url);
   }
   else if (pathBeforeCaptureJS) {
-    require(pathBeforeCaptureJS)(page, callback);
+    require(pathBeforeCaptureJS)(page, callback, url);
   }
   else {
     callback();

--- a/templates/javascript/cookies_and_headers--casper.js
+++ b/templates/javascript/cookies_and_headers--casper.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (casper, ready) {
+module.exports = function (casper, ready, url) {
     // reload page with headers set
     casper.open(casper.page.url, {
         method: 'get',

--- a/templates/javascript/cookies_and_headers--phantom.js
+++ b/templates/javascript/cookies_and_headers--phantom.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (phantom, ready) {
+module.exports = function (phantom, ready, url) {
 
     page.customHeaders = {
         'SOME-HEADER': 'fish'

--- a/templates/javascript/disable_javascript--casper.js
+++ b/templates/javascript/disable_javascript--casper.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (casper, ready) {
+module.exports = function (casper, ready, url) {
     // disable JavaScript
     casper.options.pageSettings.javascriptEnabled = false;
 

--- a/templates/javascript/disable_javascript--phantom.js
+++ b/templates/javascript/disable_javascript--phantom.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (phantom, ready) {
+module.exports = function (phantom, ready, url) {
     // disable JavaScript
     phantom.settings.javascriptEnabled = false;
 

--- a/templates/javascript/interact--casper.js
+++ b/templates/javascript/interact--casper.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (casper, ready) {
+module.exports = function (casper, ready, url) {
     // test interaction on the page
     casper.wait(2000, function() {
         casper.click('.ns-panel__hotspot--2');

--- a/templates/javascript/interact--phantom.js
+++ b/templates/javascript/interact--phantom.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (phantom, ready) {
+module.exports = function (phantom, ready, url) {
 
     // test interaction on the page
     phantom.evaluate(function(){

--- a/templates/javascript/wait--casper.js
+++ b/templates/javascript/wait--casper.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (casper, ready) {
+module.exports = function (casper, ready, url) {
     // make Wraith wait a bit longer before taking the screenshot
     casper.wait(2000, ready); // you MUST call the ready() callback for Wraith to continue
 }

--- a/templates/javascript/wait--phantom.js
+++ b/templates/javascript/wait--phantom.js
@@ -2,7 +2,7 @@
 // This is an example module provided by Wraith.
 // Feel free to amend for your own requirements.
 // ######################################################
-module.exports = function (phantom, ready) {
+module.exports = function (phantom, ready, url) {
     // make Wraith wait a bit longer before taking the screenshot
     setTimeout(ready, 2000); // you MUST call the ready() callback for Wraith to continue
 }


### PR DESCRIPTION
Hi,

If the website to be captured requires login, often it would redirect to a login-page. This redirect would change the value page.url available in the beforeCaptureJS function. The login could be handled through phantomjs or casperjs, but there is no way to get the original target url.
So this change adds the target url as parameter and makes it available in the beforeCaptureJS. It's added as a new parameter at the end so it preserves backwards-compatibility with existing configurations.

regards,
Daniel