### PR TITLE
strip out single quote from cmd

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -65,7 +65,7 @@ class Wraith::SaveImages
 
   def run_command(command)
     output = []
-    ommand.gsub!(/'/, '')
+    command.gsub!(/'/, '')
     IO.popen(command).each do |line|
       logger.info line
       output << line.chomp!

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -65,6 +65,7 @@ class Wraith::SaveImages
 
   def run_command(command)
     output = []
+    ommand.gsub!(/'/, '')
     IO.popen(command).each do |line|
       logger.info line
       output << line.chomp!


### PR DESCRIPTION
fixing phantomjs v2+ in windows doesn't work issue
Related issue: https://github.com/BBC-News/wraith/issues/444