### PR TITLE
Fix for #474 - Use spider.txt if no paths defined in the config yaml.

### DIFF
--- a/lib/wraith/folder.rb
+++ b/lib/wraith/folder.rb
@@ -23,6 +23,7 @@ class Wraith::FolderManager
 
   def spider_paths
     if !paths
+      logger.debug "Read the spider file...."
       paths = File.read(wraith.spider_file)
       eval(paths)
     else
@@ -51,7 +52,7 @@ class Wraith::FolderManager
 
   def copy_base_images
     logger.info "COPYING BASE IMAGES"
-    wraith.paths.each do |path|
+    spider_paths.each do |path|
       path = path[0]
       logger.info "Copying #{history_dir}/#{path} to #{dir}"
       FileUtils.cp_r(Dir.glob("#{history_dir}/#{path}"), dir)

--- a/lib/wraith/gallery.rb
+++ b/lib/wraith/gallery.rb
@@ -68,7 +68,13 @@ class Wraith::GalleryGenerator
   end
 
   def get_path(category)
-    wraith.paths[category]["path"] || wraith.paths[category]
+    if wraith.paths
+      wraith.paths[category]["path"] || wraith.paths[category]
+    else
+      logger.debug "Read the spider file...."
+      paths = File.read(wraith.spider_file)
+      paths[category]["path"] || paths[category]
+    end
   end
 
   def get_group_from_match(match)


### PR DESCRIPTION
In gallery.rb, the spider file was flat out being ignored.
In folder.rb, the local property was not being used in the traversal.

Also added debugging to tell when the spider file is being read (which is every time, unfortunately).