### PR TITLE
added 'wraith info' command

### DIFF
--- a/lib/wraith/cli.rb
+++ b/lib/wraith/cli.rb
@@ -177,6 +177,11 @@ class Wraith::CLI < Thor
     end
   end
 
+  desc "info", "Show various info about your system"
+  def info
+    list_debug_information
+  end
+
   desc "version", "Show the version of Wraith"
   map ["--version", "-version", "-v"] => "version"
   def version

--- a/lib/wraith/helpers/utilities.rb
+++ b/lib/wraith/helpers/utilities.rb
@@ -14,3 +14,31 @@ def convert_to_absolute(filepath)
     "#{Dir.pwd}/#{filepath}"
   end
 end
+
+def list_debug_information
+  wraith_version      = Wraith::VERSION
+  command_run         = ARGV.join ' '
+  ruby_version        = run_command_safely("ruby -v") || "Ruby not installed"
+  phantomjs_version   = run_command_safely("phantomjs --version") || "PhantomJS not installed"
+  casperjs_version    = run_command_safely("casperjs --version") || "CasperJS not installed"
+  imagemagick_version = run_command_safely("convert -version") || "ImageMagick not installed"
+
+  logger.debug "#################################################"
+  logger.debug "  Command run:        #{command_run}"
+  logger.debug "  Wraith version:     #{wraith_version}"
+  logger.debug "  Ruby version:       #{ruby_version}"
+  logger.debug "  ImageMagick:        #{imagemagick_version}"
+  logger.debug "  PhantomJS version:  #{phantomjs_version}"
+  logger.debug "  CasperJS version:   #{casperjs_version}"
+  # @TODO - add a SlimerJS equivalent
+  logger.debug "#################################################"
+end
+
+def run_command_safely(command)
+  begin
+    output = `#{command}`
+  rescue StandardError
+    return false
+  end
+  output.lines.first.chomp
+end

--- a/lib/wraith/validate.rb
+++ b/lib/wraith/validate.rb
@@ -65,33 +65,4 @@ class Wraith::Validate
   def docs_prompt
     "See the docs at http://bbc-news.github.io/wraith/"
   end
-
-  def list_debug_information
-    wraith_version      = Wraith::VERSION
-    command_run         = ARGV.join ' '
-    ruby_version        = run_command_safely("ruby -v") || "Ruby not installed"
-    phantomjs_version   = run_command_safely("phantomjs --version") || "PhantomJS not installed"
-    casperjs_version    = run_command_safely("casperjs --version") || "CasperJS not installed"
-    imagemagick_version = run_command_safely("convert -version") || "ImageMagick not installed"
-
-    logger.debug "#################################################"
-    logger.debug "  Command run:        #{command_run}"
-    logger.debug "  Wraith version:     #{wraith_version}"
-    logger.debug "  Ruby version:       #{ruby_version}"
-    logger.debug "  ImageMagick:        #{imagemagick_version}"
-    logger.debug "  PhantomJS version:  #{phantomjs_version}"
-    logger.debug "  CasperJS version:   #{casperjs_version}"
-    # @TODO - add a SlimerJS equivalent
-    logger.debug "#################################################"
-    logger.debug ""
-  end
-
-  def run_command_safely(command)
-    begin
-      output = `#{command}`
-    rescue StandardError
-      return false
-    end
-    output.lines.first
-  end
 end


### PR DESCRIPTION
Useful for debugging. Rather than having to create a YML file with `verbose: true` specified, and run a command such as `wraith latest` against that YML file... you can now just run `wraith info` to see useful system information such as Wraith/Phantom/Casper/ImageMagick versions.