### PR TITLE
removed casperjs dev dependency

### DIFF
--- a/wraith.gemspec
+++ b/wraith.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'casperjs'
 
   spec.add_runtime_dependency 'rake'
   spec.add_runtime_dependency 'image_size'


### PR DESCRIPTION
Version on Rubygems is 1.0, not compatible with Phantom 2.1.1. Rubygems version should ideally be latest: 1.1.3. Rely on Wraith maintainer to have correct CasperJS installed instead.