### PR TITLE
Adds 'Imports' functionality

### DIFF
--- a/lib/wraith/helpers/utilities.rb
+++ b/lib/wraith/helpers/utilities.rb
@@ -1,5 +1,11 @@
 require "wraith/helpers/custom_exceptions"
 
+def absolute_path_of_dir(filepath)
+  path_parts = filepath.split('/')
+  path_to_dir = path_parts.first path_parts.size - 1
+  path_to_dir.join('/')
+end
+
 def convert_to_absolute(filepath)
   if !filepath
     "false"

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -41,8 +41,13 @@ class Wraith::Wraith
   end
 
   def apply_imported_config(config_to_import, config)
-    yaml = YAML.load_file("#{@config_dir}/#{config_to_import}")
-    yaml.merge(config)
+    path_to_config = "#{@config_dir}/#{config_to_import}"
+    if File.exist?(path_to_config)
+      yaml = YAML.load_file path_to_config
+      return yaml.merge(config)
+    end
+
+    fail ConfigFileDoesNotExistError, "unable to find referenced imported config \"#{config_name}\""
   end
 
   def directory

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -8,6 +8,14 @@ class Wraith::Wraith
 
   def initialize(config, yaml_passed = false)
     @config = yaml_passed ? config : open_config_file(config)
+    if @config['imports']
+      abs_path = @absolute_path_to_config.split('/')
+      abs_path = abs_path.first abs_path.size - 1
+      abs_path = abs_path.join('/')
+      yaml = YAML.load_file("#{abs_path}/#{@config['imports']}")
+      combined = yaml.merge(@config)
+      @config = combined
+    end
     logger.level = verbose ? Logger::DEBUG : Logger::INFO
   end
 
@@ -22,8 +30,8 @@ class Wraith::Wraith
 
     possible_filenames.each do |filepath|
       if File.exist?(filepath)
-        config = File.open filepath
-        return YAML.load config
+        @absolute_path_to_config = convert_to_absolute(filepath)
+        return YAML.load_file filepath
       end
     end
     fail ConfigFileDoesNotExistError, "unable to find config \"#{config_name}\""

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -16,6 +16,16 @@ describe "wraith config" do
     it "contains shot options" do
       expect(wraith.config).to include "directory" => "shots"
     end
+
+    it "should be able to import other configs" do
+      config_name = get_path_relative_to __FILE__, "./configs/test_config--imports.yaml"
+      wraith = Wraith::Wraith.new(config_name)
+
+      # retain the imported config settings
+      expect(wraith.paths).to eq("home" => "/", "uk_index" => "/uk")
+      # ...but override the imported config in places
+      expect(wraith.widths).to eq [1337]
+    end
   end
 
   describe "When creating a wraith worker" do

--- a/spec/configs/test_config--imports.yaml
+++ b/spec/configs/test_config--imports.yaml
@@ -1,0 +1,4 @@
+imports: 'test_config--phantom.yaml'
+
+screen_widths:
+  - 1337


### PR DESCRIPTION
Fixes #324.

You can now 'import' another config into your config, e.g.

a.yml:
```yaml
imports: 'b.yml'

paths:
  home: /
```

b.yml:
```yaml
browser: "phantomjs"
```

This is exactly the same as having one YML file with these contents:

```yaml
paths:
  home: /

browser: "phantomjs"
```