### PR TITLE
Improve keyboard accessibility of slideshow gallery

### DIFF
--- a/lib/wraith/gallery_template/slideshow_template.erb
+++ b/lib/wraith/gallery_template/slideshow_template.erb
@@ -109,6 +109,7 @@
   <script type="text/javascript">
     $(function() {
       var slideshow = $('.slideshow');
+      var compareModal = $('.compare-modal');
 
       slideshow.cycle({
         fx:     'scrollHorz',
@@ -117,15 +118,25 @@
         next:   '.next',
         before: function (curr, next, opts) {
           $('.current').removeClass('current');
-          var path = $(next).find('.path').attr('name');
+          var $next = $(next);
+          var path = $next.find('.path').attr('name');
           $.each($('.list-group .list-group-item a'), function() {
             if ($(this).attr('href').substring(1) == path) {
               $(this).parent().addClass('checked');
               $(this).parent().addClass('current');
             }
-          })
+          });
+
+          var newImage = $next.find('a.shot:eq(0)').attr('href');
+          var oldImage = $next.find('a.shot:eq(1)').attr('href');
+          var diffImage = $next.find('a.shot:eq(2)').attr('href');
+          compareModal.html('<div class="compare-container"><img src="'+newImage+'"/><img src="'+oldImage+'"/><img src="'+diffImage+'"/></div>');
         },
         timeout: 0
+      });
+
+      $(document).on('click', '.compare', function() {
+        compareModal.show();
       });
 
       $('.list-group .list-group-item a').unbind().on('click', function(){
@@ -140,21 +151,16 @@
         window.open(url,'_blank');
       })
 
-      $('.compare').unbind().on('click', function(){
-        var slide = $(this).closest(".slide"),
-            newImage = slide.find('a.shot:eq(0)').attr('href'),
-            oldImage = slide.find('a.shot:eq(1)').attr('href'),
-            diffImage = slide.find('a.shot:eq(2)').attr('href');
-        $('.container').append('<div class="compare-modal"><div class="compare-container"><img src="'+newImage+'"/><img src="'+oldImage+'"/><img src="'+diffImage+'"/></div></div>');
-        $('.compare-modal').unbind().on('click', function(){
-          $(this).remove();
-        })
-      })
+      compareModal.on('click', function(){
+        $(this).remove();
+      });
 
       $(document).on('keyup', function(e) {
-        if (e.keyCode === 37) {
+        if (e.keyCode === 27) { // Escape
+          compareModal.hide();
+        } else if (e.keyCode === 37) { // Left
           slideshow.cycle('prev');
-        } else if (e.keyCode === 39) {
+        } else if (e.keyCode === 39) { // Right
           slideshow.cycle('next');
         }
       });
@@ -162,6 +168,7 @@
 </script>
 </head>
 <body>
+  <div class="compare-modal" style="display: none;"></div>
   <div class="container">
     <div class="row">
       <div class="col-sm-12 col-md-3">

--- a/lib/wraith/gallery_template/slideshow_template.erb
+++ b/lib/wraith/gallery_template/slideshow_template.erb
@@ -152,7 +152,7 @@
       })
 
       compareModal.on('click', function(){
-        $(this).remove();
+        $(this).hide();
       });
 
       $(document).on('keyup', function(e) {

--- a/lib/wraith/gallery_template/slideshow_template.erb
+++ b/lib/wraith/gallery_template/slideshow_template.erb
@@ -108,7 +108,9 @@
   </style>
   <script type="text/javascript">
     $(function() {
-      $('.slideshow').cycle({
+      var slideshow = $('.slideshow');
+
+      slideshow.cycle({
         fx:     'scrollHorz',
         speed:  300,
         prev:   '.prev',
@@ -129,7 +131,7 @@
       $('.list-group .list-group-item a').unbind().on('click', function(){
         var href = $(this).attr('href').substring(1);
 
-        $('.slideshow').cycle($('.slide.'+href+':first').index());
+        slideshow.cycle($('.slide.'+href+':first').index());
       })
 
       $('.shot').unbind().on('click', function(e){
@@ -148,6 +150,14 @@
           $(this).remove();
         })
       })
+
+      $(document).on('keyup', function(e) {
+        if (e.keyCode === 37) {
+          slideshow.cycle('prev');
+        } else if (e.keyCode === 39) {
+          slideshow.cycle('next');
+        }
+      });
     })
 </script>
 </head>


### PR DESCRIPTION
This is just scratching an itch that I had.

 * Support for cycling through the slideshow and the lightbox using arrow keys
 * Lightbox can be closed with the Escape key

If you want a quick way to test this, you can pretty much copy from `<div class="compare-modal" style="display: none;"></div>` to `<head>` into an existing gallery and see the magic.

![wraith-arrow-keys](https://cloud.githubusercontent.com/assets/794263/23520782/43665b12-ff74-11e6-8e10-864ca33819fa.gif)
