### PR TITLE
Add option to add custom templates and fix screenshot cut off 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wraith.gemspec
+
+gem 'wraith', :git => 'https://github.com/gemmageee/wraith.git', :branch => 'master'
+
 gemspec

--- a/lib/wraith/gallery.rb
+++ b/lib/wraith/gallery.rb
@@ -141,7 +141,7 @@ class Wraith::GalleryGenerator
     dest = "#{@location}/gallery.html"
     directories = parse_directories(@location)
 
-    template = File.expand_path("gallery_template/#{wraith.gallery_template}.erb", File.dirname(__FILE__))
+    template = File.expand_path(Dir.pwd + "/gallery_template/#{wraith.gallery_template}.erb", File.dirname(__FILE__))
     generate_html(@location, directories, template, dest, with_path)
 
     report_gallery_status dest

--- a/lib/wraith/javascript/phantom.js
+++ b/lib/wraith/javascript/phantom.js
@@ -132,12 +132,6 @@ function resizeAndCaptureImage() {
 
 function takeScreenshot() {
   console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
-  page.clipRect = {
-    top: 0,
-    left: 0,
-    height: currentDimensions.viewportHeight,
-    width: currentDimensions.viewportWidth
-  };
   page.render(image_name);
 }
 


### PR DESCRIPTION
The screenshots that get taken are cut off at the fold. This fix takes the full web page, regardless of screen height. 

We wanted an option to customise the results page. So added a gallery_template folder and changed the ruby file to point at this custom folder. Now anyone can copy the basic_template.erb and customise it, then save it in this folder. 