### PR TITLE
The 'latest' command is broken

### DIFF
--- a/lib/wraith/cli.rb
+++ b/lib/wraith/cli.rb
@@ -155,6 +155,7 @@ class Wraith::CLI < Thor
     within_acceptable_limits do
       logger.info Wraith::Validate.new(config).validate("latest")
       reset_shots(config)
+      setup_folders(config)
       save_images(config, true)
       copy_base_images(config)
       crop_images(config)


### PR DESCRIPTION
This fixes #555

The ``latest`` command is trying to save the images to a non existing directory.

It is necessary to create the directory structure before start saving the images.

