### PR TITLE
Add ability to capture entire page screenshot using phantomjs.

### DIFF
--- a/lib/wraith/javascript/_helper.js
+++ b/lib/wraith/javascript/_helper.js
@@ -1,12 +1,14 @@
+const DEFAULT_HEIGHT = 1500;
+    
 module.exports = function (commandLineDimensions) {
-
+    
     commandLineDimensions = '' + commandLineDimensions; // cast to string
 
     function getWidthAndHeight(dimensions) {
         dimensions = /(\d*)x?((\d*))?/i.exec(dimensions);
         return {
             'viewportWidth':  parseInt(dimensions[1]),
-            'viewportHeight': parseInt(dimensions[2] || 1500)
+            'viewportHeight': parseInt(dimensions[2] || 0)
         };
     }
 
@@ -34,12 +36,27 @@ module.exports = function (commandLineDimensions) {
             var dirs = image_name.split('/'),
                 filename = dirs[dirs.length - 1],
                 filenameParts = filename.split('_'),
-                newFilename;
+                newFilename,
+                viewportHeight = (
+                  currentDimensions.viewportHeight === 0
+                  ? DEFAULT_HEIGHT
+                  : currentDimensions.viewportHeight
+                );
 
-            filenameParts[0] = currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight;
+            filenameParts[0] = currentDimensions.viewportWidth + 'x' + viewportHeight;
             dirs.pop(); // remove MULTI_casperjs_english.png
             newFilename = dirs.join('/') + '/' + filenameParts.join('_');
             return newFilename;
+        },
+        getViewportSize: function(currentDimensions) {
+            return {
+                width: currentDimensions.viewportWidth,
+                height: (
+                    currentDimensions.viewportHeight === 0
+                    ? DEFAULT_HEIGHT
+                    : currentDimensions.viewportHeight
+                )
+            };
         }
     }
 }

--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -37,7 +37,8 @@ function snap() {
   if (helper.takingMultipleScreenshots(dimensions) && dimensionsProcessed < dimensions.length) {
     currentDimensions = dimensions[dimensionsProcessed];
     image_name = helper.replaceImageNameWithDimensions(image_name, currentDimensions);
-    casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeight);
+    viewportSize = helper.getViewportSize(currentDimensions);
+    casper.viewport(viewportSize.width, viewportSize.height);
     casper.wait(300, function then () {
       snap.bind(this)();
     });
@@ -55,7 +56,8 @@ else {
 // Casper can now do its magic
 casper.start();
 casper.open(url);
-casper.viewport(currentDimensions.viewportWidth, currentDimensions.viewportHeight);
+viewportSize = helper.getViewportSize(currentDimensions);
+casper.viewport(viewportSize.width, viewportSize.height);
 casper.then(function() {
   var self = this;
   if (globalBeforeCaptureJS && pathBeforeCaptureJS) {

--- a/lib/wraith/javascript/phantom.js
+++ b/lib/wraith/javascript/phantom.js
@@ -11,7 +11,8 @@ var url        = system.args[1],
     globalBeforeCaptureJS = system.args[5],
     pathBeforeCaptureJS = system.args[6],
     dimensionsProcessed = 0,
-    currentDimensions;
+    currentDimensions,
+    viewportSize;
 
 globalBeforeCaptureJS = globalBeforeCaptureJS === 'false' ? false : globalBeforeCaptureJS;
 pathBeforeCaptureJS   = pathBeforeCaptureJS === 'false' ? false : pathBeforeCaptureJS;
@@ -52,8 +53,10 @@ page.onResourceReceived = function(res) {
   }
 };
 
-console.log('Loading ' + url + ' at dimensions: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
-page.viewportSize = { width: currentDimensions.viewportWidth, height: currentDimensions.viewportHeight};
+
+viewportSize = helper.getViewportSize(currentDimensions);
+console.log('Loading ' + url + ' at dimensions: ' + viewportSize.width + 'x' + viewportSize.height);
+page.viewportSize = viewportSize;
 
 page.open(url, function(status) {
   if (status !== 'success') {
@@ -125,19 +128,22 @@ function captureImage() {
 }
 
 function resizeAndCaptureImage() {
-  console.log('Resizing ' + url + ' to: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
-  page.viewportSize = { width: currentDimensions.viewportWidth, height: currentDimensions.viewportHeight};
+  viewportSize = helper.getViewportSize(currentDimensions);
+  console.log('Resizing ' + url + ' to: ' + viewportSize.width + 'x' + viewportSize.height);
+  page.viewportSize = viewportSize;
   setTimeout(captureImage, 5000); // give page time to re-render properly
 }
 
 function takeScreenshot() {
   console.log('Snapping ' + url + ' at: ' + currentDimensions.viewportWidth + 'x' + currentDimensions.viewportHeight);
-  page.clipRect = {
-    top: 0,
-    left: 0,
-    height: currentDimensions.viewportHeight,
-    width: currentDimensions.viewportWidth
-  };
+  if (currentDimensions.viewportHeight !== 0) {
+    page.clipRect = {
+      top: 0,
+      left: 0,
+      height: currentDimensions.viewportHeight,
+      width: currentDimensions.viewportWidth
+    };
+  }
   page.render(image_name);
 }
 


### PR DESCRIPTION
When using phantomjs, if no height is passed in on the command line, e.g. '1280', assume that a full screenshot is being requested.  Still set the viewport size to the old default (1500) but do not set the clip rect when calling render().

*NOTE:* this does introduce a potentially breaking change if there are current implementations that depend on the default using a cliprect with a height of 1500.  I don't know that this is entirely useful but it is worth considering a different option, e.g. specifically using a keyword/marker to indicate the default height, e.g. '1280xauto' or something similar.