### PR TITLE
Windows : disk letter in lower case and before_capture option

### DIFF
--- a/lib/wraith/helpers/utilities.rb
+++ b/lib/wraith/helpers/utilities.rb
@@ -19,7 +19,7 @@ def convert_to_absolute(filepath)
   elsif filepath[0] == "/"
     # filepath is already absolute. return unchanged
     filepath
-  elsif filepath.match(/^[A-Z]:\/(.+)$/)
+  elsif filepath.match(/^[A-Za-z]:\/(.+)$/)
     # filepath is an absolute Windows path, e.g. C:/Code/Wraith/javascript/global.js. return unchanged
     filepath
   else


### PR DESCRIPTION
Hi,

On Windows, the disk letter is not always uppercase. It could cause a bug with `before_capture` option.

Example: 

My option : 
`before_capture: 'javascript/wait--casper.js'`

I start cmd, the default path is `C:\Users\my-user`.
So i can enter this commands to go to the good path : 
```
C:\Users\my-user> cd f:\project
C:\Users\my-user> f:
f:\project>wraith capture configs/spider.yaml`
```
This causes an error : 
`Can't find module f:/project/f:/project/javascript/wait--casper.js`

It is because of the regex in `convert_to_absolute` function which wants an uppercase letter for the disk.

This PR modify the regex to accept a lowercase letter too.

