### PR TITLE
Swap driver.execute_script for async version in Chrome

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -136,8 +136,8 @@ class Wraith::SaveImages
           driver.manage.window.resize_to(width, height || 1500)
           driver.navigate.to url
           driver.manage.timeouts.implicit_wait = wraith.settle
-          driver.execute_script(File.read(global_before_capture)) if global_before_capture
-          driver.execute_script(File.read(path_before_capture)) if path_before_capture
+          driver.execute_async_script(File.read(global_before_capture)) if global_before_capture
+          driver.execute_async_script(File.read(path_before_capture)) if path_before_capture
           resize_to_fit_page(driver) unless height
           driver.save_screenshot(new_file_name)
           crop_selector(driver, selector, new_file_name) if selector && selector.length > 0

--- a/spec/js/global--chrome.js
+++ b/spec/js/global--chrome.js
@@ -1,4 +1,6 @@
+var callback = arguments[arguments.length-1];
 (function () {
     document.body.innerHTML = "&nbsp;";
     document.body.style['background-color'] = 'red';
+    callback();
 })();

--- a/spec/js/path--chrome.js
+++ b/spec/js/path--chrome.js
@@ -1,4 +1,6 @@
+var callback = arguments[arguments.length-1];
 (function () {
     document.body.innerHTML = "&nbsp;";
     document.body.style['background-color'] = 'green';
+    callback();
 })();


### PR DESCRIPTION
execute_script runs synchronously, whereas execute_async_script provides
a callback argument to the script. This makes the before capture scripts
for Chrome more like the ones for Phantom and Casper and allows users
to do more advanced things in their before_captures.