### PR TITLE
Add base_path and compare_path options for paths

### DIFF
--- a/lib/wraith/gallery.rb
+++ b/lib/wraith/gallery.rb
@@ -3,6 +3,7 @@ require "pp"
 require "fileutils"
 require "wraith/wraith"
 require "wraith/helpers/logger"
+require "wraith/helpers/capture_options"
 
 class Wraith::GalleryGenerator
   include Logging
@@ -60,15 +61,22 @@ class Wraith::GalleryGenerator
   end
 
   def figure_out_url(group, category)
-    root = wraith.domains["#{group}"]
+    group = "#{group}"
+    root = wraith.domains[group]
+    base_or_compare = wraith.domains.keys.index(group) == 0 ? :base : :compare
     return "" if root.nil?
-    path = get_path(category)
+    path = get_path(category, base_or_compare)
     url  = root + path
     url
   end
 
-  def get_path(category)
-    wraith.paths[category]["path"] || wraith.paths[category]
+  def get_path(category, base_or_compare)
+    path_options = CaptureOptions.new(wraith.paths[category], wraith)
+    if base_or_compare == :base
+      path_options.base_path
+    else
+      path_options.compare_path
+    end
   end
 
   def get_group_from_match(match)

--- a/lib/wraith/helpers/capture_options.rb
+++ b/lib/wraith/helpers/capture_options.rb
@@ -13,6 +13,14 @@ class CaptureOptions
     casper?(options)
   end
 
+  def base_path
+    options.is_a?(Hash) && options.key?('base_path') ? options['base_path'] : path
+  end
+
+  def compare_path
+    options.is_a?(Hash) && options.key?('compare_path') ? options['compare_path'] : path
+  end
+
   def selector
     options["selector"] || "body"
   end
@@ -31,11 +39,11 @@ class CaptureOptions
   end
 
   def base_url
-    base_urls(path)
+    base_urls(base_path)
   end
 
   def compare_url
-    compare_urls(path)
+    compare_urls(compare_path)
   end
 
   def base_urls(path)

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -53,8 +53,8 @@ class Wraith::SaveImages
     compare_file_name = meta.file_names(width, label, meta.compare_label)
 
     jobs = []
-    jobs << [label, settings.path, prepare_widths_for_cli(width), settings.base_url,    base_file_name,    settings.selector, wraith.before_capture, settings.before_capture, 'invalid1.jpg']
-    jobs << [label, settings.path, prepare_widths_for_cli(width), settings.compare_url, compare_file_name, settings.selector, wraith.before_capture, settings.before_capture, 'invalid2.jpg'] unless settings.compare_url.nil?
+    jobs << [label, settings.base_path, prepare_widths_for_cli(width), settings.base_url,    base_file_name,    settings.selector, wraith.before_capture, settings.before_capture, 'invalid1.jpg']
+    jobs << [label, settings.compare_path, prepare_widths_for_cli(width), settings.compare_url, compare_file_name, settings.selector, wraith.before_capture, settings.before_capture, 'invalid2.jpg'] unless settings.compare_url.nil?
 
     jobs
   end

--- a/spec/configs/test_config--base_compare_paths.yaml
+++ b/spec/configs/test_config--base_compare_paths.yaml
@@ -1,0 +1,9 @@
+imports: 'test_config--phantom.yaml'
+
+paths:
+  home:
+    base_path: /old-home
+    compare_path: /new-home
+  uk_index:
+    base_path: /old-uk
+    compare_path: /new-uk

--- a/spec/gallery_spec.rb
+++ b/spec/gallery_spec.rb
@@ -28,4 +28,33 @@ describe Wraith do
       expect(dirs["home"][0][:diff][:thumb]).to eq "thumbnails/home/test_image-diff.png"
     end
   end
+
+  describe "#figure_out_url" do
+    it "returns an empty string if it can't find the domain" do
+      expect(gallery.figure_out_url("missing_domain", "home")).to eq ""
+    end
+
+    it "returns a full url" do
+      expected = "http://www.bbc.com/afrique/"
+      expect(gallery.figure_out_url("afrique", "home")).to eq expected
+    end
+
+    context "when base_path and compare_path are set" do
+      let(:config_name) do
+        get_path_relative_to __FILE__,
+                            "./configs/test_config--base_compare_paths.yaml"
+      end
+      let(:gallery) { Wraith::GalleryGenerator.new(config_name, false) }
+
+      it "uses the base path for the first domain" do
+        expected = "http://www.bbc.com/afrique/old-home"
+        expect(gallery.figure_out_url("afrique", "home")).to eq expected
+      end
+
+      it "uses the compare path for the second domain" do
+        expected = "http://www.bbc.com/russian/new-home"
+        expect(gallery.figure_out_url("russian", "home")).to eq expected
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds the option to supply two different paths for particular pages,
for instances where the url changes between domains (e.g. testing a
migration to a new slug library or a new CMS).

This probably needs someone with a bit more of an architectural 
overview to weigh in, because our use-case is quite limited and so I
doubt I've met all the edge-cases that this might affect.

Closes #552