### PR TITLE
Escape pathnames for shell in compare_images.rb [Fixes #527]

### DIFF
--- a/lib/wraith/compare_images.rb
+++ b/lib/wraith/compare_images.rb
@@ -31,7 +31,7 @@ class Wraith::CompareImages
   end
 
   def compare_task(base, compare, output, info)
-    cmdline = "compare -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare.shellescape} #{output}"
+    cmdline = "compare -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base.shellescape} #{compare.shellescape} #{output.shellescape}"
     px_value = Open3.popen3(cmdline) { |_stdin, _stdout, stderr, _wait_thr| stderr.read }.to_f
     begin
       img_size = ImageSize.path(output).size.inject(:*)


### PR DESCRIPTION
## Bug
Having namespaced paths with spaces causes the `compare_images.rb` script to hang or fail. This was reported in #527. 

**Example Bad Path in Wraith Config File**
```yaml
paths:
  Site Home: /home.html
```

This bug is happening because the constructed shell command in `compare_images.rb` does not escape the supplied pathnames resulting in a faulty `compare` CLI command. 

## What this PR does

The changes ensure the pathnames are escaped for the shell. 

This will allow people to use spaces for their named paths and the `compare_images.rb` script can correctly compare the files and generate the diff image. 