### PR TITLE
FIX: Addressing typo in screensize 

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -143,7 +143,7 @@ class Wraith::SaveImages
           crop_selector(driver, selector, new_file_name) if selector && selector.length > 0
           break
         rescue Net::ReadTimeout => e
-          logger.error "Got #{e} on attempt #{attempt} at screen size #{screensize}. URL = #{url}"
+          logger.error "Got #{e} on attempt #{attempt} at screen size #{screen_size}. URL = #{url}"
         end
       end
     end


### PR DESCRIPTION
An unrecoverable stack trace occurs right now in case there's a read timeout (happens on my VM frequently on one particularly large page). Easily fixed by correcting a typo.

In my case I am running in Mingw-w64 on Windows 10 but I don't think that makes a difference.

**Stack trace:**
```
C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:906:in `rescue in block in connect': Failed to open TCP connection to 127.0.0.1:9518 (No connection could be made because the target machine actively refused it. - connect(2) for "127.0.0.1" port 9518) (Errno::ECONNREFUSED)
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:903:in `block in connect'
        from C:/Ruby24-x64/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
        from C:/Ruby24-x64/lib/ruby/2.4.0/timeout.rb:103:in `timeout'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:902:in `connect'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:1485:in `begin_transport'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:1442:in `transport_request'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:1416:in `request'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:1165:in `get'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:185:in `block in stop_server'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:160:in `block in connect_to_server'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:877:in `start'
        from C:/Ruby24-x64/lib/ruby/2.4.0/net/http.rb:608:in `start'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:156:in `connect_to_server'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:185:in `stop_server'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:118:in `stop'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/platform.rb:150:in `block in exit_hook'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/wraith-4.2.4/lib/wraith/save_images.rb:89:in `rescue in block in parallel_task': undefined local variable or method `invalid_image_name' for #<Wraith::SaveImages:0x0000000002d58548> (NameError)
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/wraith-4.2.4/lib/wraith/save_images.rb:80:in `block in parallel_task'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/parallel-1.17.0/lib/parallel.rb:506:in `call_with_index'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/parallel-1.17.0/lib/parallel.rb:360:in `block (2 levels) in work_in_threads'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/parallel-1.17.0/lib/parallel.rb:515:in `with_instrumentation'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/parallel-1.17.0/lib/parallel.rb:359:in `block in work_in_threads'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/parallel-1.17.0/lib/parallel.rb:209:in `block (3 levels) in in_threads'
Config validated. No serious issues found.
Creating Folders
SAVING IMAGES
ERROR: undefined local variable or method `screensize' for #<Wraith::SaveImages:0x0000000002d58548>
Did you mean?  screen_size
               screen_sizes
  URL = http://127.0.0.1/our-company/our-history/

```